### PR TITLE
Modify run_tasks to properly propagate errors

### DIFF
--- a/07-advanced.rst
+++ b/07-advanced.rst
@@ -80,7 +80,7 @@ simple task loader by inheriting from the `TaskLoader` base class, like so:
             def load_tasks(cmd, opt_values, pos_args):
                 return tasks, config
        
-        DoitMain(Loader()).run(args)
+        return DoitMain(Loader()).run(args)
 
 If this all seems a little obtuse, don't be alarmed; this is most of what you need to start
 writing your own applications with doit. The `TaskLoader` is what parses a file or object and


### PR DESCRIPTION
A perhaps better alternative is to define a specialty exception and then raise that, which is what I ended up actually using in cats-in-practice.
